### PR TITLE
wanderers Release 0.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.0.2] - 2025-01-27
+
 ## [0.0.1] - 2025-01-27
 
 ### Added
@@ -25,5 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CODEOWNERS file to track mandatory reviewers of certain PRs
 
 -----
-[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.1...HEAD
+[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/isaacchunn/wanderers/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/isaacchunn/wanderers/releases/tag/v0.0.1


### PR DESCRIPTION
Release notes: ## [0.0.2] - 2025-01-27


Release URL: https://github.com/isaacchunn/wanderers/releases/tag/untagged-d73c3ee343345bac957c
Please review and merge this PR to complete the release process.