### PR TITLE
wanderers release v0.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,15 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Full automation of our release process by running generate_release.py
-
 ### Fixed
 
 ### Changed
 
-- File name of generate_release.py file
-
 ### Removed
+
+## [0.0.2] - 2025-01-27
+
+### Added
+
+- Full automation of our release process by running generate_release.py
+
+### Changed
+
+- File name of generate_release.py file
 
 ## [0.0.1] - 2025-01-27
 
@@ -29,5 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CODEOWNERS file to track mandatory reviewers of certain PRs
 
 -----
-[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.1...HEAD
+[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/isaacchunn/wanderers/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/isaacchunn/wanderers/releases/tag/v0.0.1


### PR DESCRIPTION
Release notes:
## [0.0.2] - 2025-01-27

### Added

- Full automation of our release process by running generate_release.py

### Changed

- File name of generate_release.py file


Release URL: https://github.com/isaacchunn/wanderers/releases/tag/untagged-4b07e11b10db10d935fe
Please review and merge this PR to complete the release process.