### PR TITLE
wanderers release v0.0.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.0.3] - 2025-01-28
+
+### Fixed
+
+- Login page rendering issues
+
 ## [0.0.2] - 2025-01-27
 
 ### Added
@@ -35,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CODEOWNERS file to track mandatory reviewers of certain PRs
 
 -----
-[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.2...HEAD
+[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/isaacchunn/wanderers/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/isaacchunn/wanderers/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/isaacchunn/wanderers/releases/tag/v0.0.1


### PR DESCRIPTION
Release notes:
## [0.0.3] - 2025-01-28

### Fixed

- Login page rendering issues


Release URL: https://github.com/isaacchunn/wanderers/releases/tag/untagged-01ea761b737ba7b9e762
Please review and merge this PR to complete the release process.