### PR TITLE
wanderers release v0.0.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial Express API Backend with Signup and Login
-
 ### Fixed
 
 ### Changed
 
 ### Removed
+
+## [0.0.3] - 2025-02-01
+
+### Added
+
+- Initial Express API Backend with Signup and Login
 
 ## [0.0.2] - 2025-01-27
 
@@ -37,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CODEOWNERS file to track mandatory reviewers of certain PRs
 
 ---
-
-[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.2...HEAD
+[unreleased]: https://github.com/isaacchunn/wanderers/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/isaacchunn/wanderers/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/isaacchunn/wanderers/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/isaacchunn/wanderers/releases/tag/v0.0.1


### PR DESCRIPTION
Release notes:
## [0.0.3] - 2025-02-01

### Added

- Initial Express API Backend with Signup and Login


Release URL: https://github.com/isaacchunn/wanderers/releases/tag/untagged-cb08f5de2b1edbe64333
Please review and merge this PR to complete the release process.