### PR TITLE
wanderers release v1.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.1.0] - 2025-03-25
+
 ## [1.0.0] - 2025-03-12
 
 ### Added
@@ -106,7 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CODEOWNERS file to track mandatory reviewers of certain PRs
 
 ---
-[unreleased]: https://github.com/isaacchunn/wanderers/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/isaacchunn/wanderers/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/isaacchunn/wanderers/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/isaacchunn/wanderers/compare/v0.0.4...v1.0.0
 [0.0.4]: https://github.com/isaacchunn/wanderers/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/isaacchunn/wanderers/compare/v0.0.2...v0.0.3


### PR DESCRIPTION
Release notes:
## [1.1.0] - 2025-03-25


Release URL: https://github.com/isaacchunn/wanderers/releases/tag/untagged-2325ed5776f0d1ad4405
Please review and merge this PR to complete the release process.